### PR TITLE
Doctor updates

### DIFF
--- a/server/src/main/java/com/clinicare/server/controller/ClinicController.java
+++ b/server/src/main/java/com/clinicare/server/controller/ClinicController.java
@@ -1,15 +1,12 @@
 package com.clinicare.server.controller;
 
 import com.clinicare.server.domain.db.Clinic;
-import com.clinicare.server.domain.db.Location;
-import com.clinicare.server.repository.LocationRepository;
 import com.clinicare.server.service.ClinicService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,9 +16,6 @@ public class ClinicController {
 
     @Autowired
     private ClinicService clinicService;
-
-    @Autowired
-    private LocationRepository locationRepository;
 
 
     @GetMapping
@@ -39,57 +33,66 @@ public class ClinicController {
         return ResponseEntity.status(HttpStatus.CREATED).body(clinicService.saveOrUpdate(clinic));
     }
 
+//    @PutMapping("/{id}")
+//    public ResponseEntity<?> update(@PathVariable Long id, @RequestBody Clinic clinic) {
+//        Optional<Clinic> desiredClinic = clinicService.findById(id);
+//        if (desiredClinic.isEmpty()) {
+//            return ResponseEntity.notFound().build();
+//        }
+//
+//        clinic.setId(id);
+//
+//        // if no locations sent in the body, the locations will stay the same
+//        if (clinic.getLocations().isEmpty()) {
+//            clinic.setLocations(desiredClinic.get().getLocations());
+//        } else {
+//            // initiating a list that will contain the updated or created locations
+//            List<Location> updatedLocations = new ArrayList<>();
+//            // checking if the array is not null too
+//            if (clinic.getLocations() != null) {
+//                for (Location newLocation : clinic.getLocations()) {
+//                    // checking if location obj has id so it's already a saved once
+//                    if (newLocation.getId() != null) {
+//                        Location existingLocation = locationRepository.findById(newLocation.getId())
+//                                .orElseThrow(() -> new IllegalArgumentException("Location with id " + newLocation.getId() + " not found"));
+//                        // setting the found location to current new data from request and overwriting its clinic {could be a problem but later ...}
+//                        existingLocation.setAddressLine(newLocation.getAddressLine());
+//                        existingLocation.setCity(newLocation.getCity());
+//                        existingLocation.setClinic(clinic);
+//                        updatedLocations.add(existingLocation);
+//                    } else {
+//                        // Creating new location
+//                        Location newLoc = new Location();
+//                        newLoc.setAddressLine(newLocation.getAddressLine());
+//                        newLoc.setCity(newLocation.getCity());
+//                        newLoc.setClinic(clinic);
+//                        updatedLocations.add(newLoc);
+//
+//                    }
+//                }
+//            }
+//            // setting locations to the newly updated clinic object
+//            clinic.setLocations(updatedLocations);
+//        }
+//        return ResponseEntity.status(HttpStatus.OK).body(clinicService.saveOrUpdate(clinic));
+//    }
+
     @PutMapping("/{id}")
-    public ResponseEntity<?> update(@PathVariable Long id, @RequestBody Clinic clinic) {
-        Optional<Clinic> desiredClinic = clinicService.findById(id);
-        if (desiredClinic.isEmpty()) {
-            return ResponseEntity.notFound().build();
+    public ResponseEntity<?> update(@PathVariable Long id, @RequestBody Clinic requestClinic) {
+        Optional<Clinic> clinic = clinicService.findById(id);
+        if (clinic.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("clinic not found");
         }
-
-        clinic.setId(id);
-
-        // if no locations sent in the body, the locations will stay the same
-        if (clinic.getLocations().isEmpty()) {
-            clinic.setLocations(desiredClinic.get().getLocations());
-        } else {
-            // initiating a list that will contain the updated or created locations
-            List<Location> updatedLocations = new ArrayList<>();
-            // checking if the array is not null too
-            if (clinic.getLocations() != null) {
-                for (Location newLocation : clinic.getLocations()) {
-                    // checking if location obj has id so it's already a saved once
-                    if (newLocation.getId() != null) {
-                        Location existingLocation = locationRepository.findById(newLocation.getId())
-                                .orElseThrow(() -> new IllegalArgumentException("Location with id " + newLocation.getId() + " not found"));
-                        // setting the found location to current new data from request and overwriting its clinic {could be a problem but later ...}
-                        existingLocation.setAddressLine(newLocation.getAddressLine());
-                        existingLocation.setCity(newLocation.getCity());
-                        existingLocation.setClinic(clinic);
-                        updatedLocations.add(existingLocation);
-                    } else {
-                        // Creating new location
-                        Location newLoc = new Location();
-                        newLoc.setAddressLine(newLocation.getAddressLine());
-                        newLoc.setCity(newLocation.getCity());
-                        newLoc.setClinic(clinic);
-                        updatedLocations.add(newLoc);
-
-                    }
-                }
-            }
-            // setting locations to the newly updated clinic object
-            clinic.setLocations(updatedLocations);
-        }
-        return ResponseEntity.status(HttpStatus.OK).body(clinicService.saveOrUpdate(clinic));
+        requestClinic.setId(clinic.get().getId());
+        return ResponseEntity.status(HttpStatus.OK).body(clinicService.saveOrUpdate(requestClinic));
     }
+
 
     @DeleteMapping("/{id}")
     public ResponseEntity<String> delete(@PathVariable Long id) {
-        Optional<Clinic> clinic = Optional.ofNullable(clinicService.findById(id).orElseThrow(
-                ()-> new IllegalArgumentException("clinic with this id isn't found"))
-        );
-        if (clinic.isEmpty())
-        {
+        Optional<Clinic> clinic = clinicService.findById(id);
+
+        if (clinic.isEmpty()) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body("clinic not found");
         }
         clinicService.delete(clinic.get().getId());

--- a/server/src/main/java/com/clinicare/server/controller/DoctorController.java
+++ b/server/src/main/java/com/clinicare/server/controller/DoctorController.java
@@ -28,17 +28,22 @@ public class DoctorController {
 
     @PostMapping
     public ResponseEntity<?> save(@RequestBody Doctor doctor) {
+        //TODO using DTOs
         return ResponseEntity.ok(doctorService.saveOrUpdate(doctor));
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<?> update(@PathVariable Long id, @RequestBody Doctor doctor)
     {
+        //TODO using DTOs
         Optional<Doctor> desiredDoctor = doctorService.findById(id);
         if(desiredDoctor.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
         doctor.setId(id);
+        if(doctor.getPassword() == null)
+            doctor.setPassword(desiredDoctor.get().getPassword());
+        doctor.setCreatedAt(desiredDoctor.get().getCreatedAt());
         return ResponseEntity.ok(doctorService.saveOrUpdate(doctor));
     }
 

--- a/server/src/main/java/com/clinicare/server/controller/LocationController.java
+++ b/server/src/main/java/com/clinicare/server/controller/LocationController.java
@@ -1,0 +1,33 @@
+package com.clinicare.server.controller;
+
+import com.clinicare.server.domain.db.Location;
+import com.clinicare.server.service.LocationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/locations")
+public class LocationController {
+    @Autowired
+    private LocationService locationService;
+
+    @PostMapping
+    public ResponseEntity<Location> save(@RequestBody Location location)
+    {
+        return ResponseEntity.ok(locationService.saveOrUpdate(location));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> update(@PathVariable Long id, @RequestBody Location requestLocation)
+    {
+        Optional<Location> location = locationService.findById(id);
+        if (location.isEmpty())
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("location doesn't exist");
+        requestLocation.setId(location.get().getId());
+        return ResponseEntity.ok(locationService.saveOrUpdate(requestLocation));
+    }
+}

--- a/server/src/main/java/com/clinicare/server/domain/db/Clinic.java
+++ b/server/src/main/java/com/clinicare/server/domain/db/Clinic.java
@@ -34,17 +34,8 @@ public class Clinic {
 //    @JsonManagedReference(value = "clinic-doctorClinics")
 //    private List<DoctorClinic> doctorClinicList;
 
-    @ManyToMany(mappedBy = "clinics")
+    @ManyToMany(mappedBy = "doctorClinics")
     @JsonIgnoreProperties("clinics")
     private List<Doctor> doctors;
-
-    
-    @OneToMany(mappedBy ="clinic")
-    @JsonIgnore
-    private Set<Slot> slots;
-
-    @OneToMany(mappedBy ="clinic")
-    @JsonIgnore
-    private Set<Appointment> appointments;
 
 }

--- a/server/src/main/java/com/clinicare/server/domain/db/Clinic.java
+++ b/server/src/main/java/com/clinicare/server/domain/db/Clinic.java
@@ -1,7 +1,6 @@
 package com.clinicare.server.domain.db;
 
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
@@ -31,9 +30,13 @@ public class Clinic {
     @JsonIgnoreProperties("clinic")
     private List<Location> locations = new ArrayList<>();
 
-    @OneToMany(mappedBy = "clinic", orphanRemoval = true)
-    @JsonBackReference(value = "clinic-doctorClinics")
-    private List<DoctorClinic> doctorClinicList;
+//    @OneToMany(mappedBy = "clinic", orphanRemoval = true, cascade = CascadeType.ALL)
+//    @JsonManagedReference(value = "clinic-doctorClinics")
+//    private List<DoctorClinic> doctorClinicList;
+
+    @ManyToMany(mappedBy = "clinics")
+    @JsonIgnoreProperties("clinics")
+    private List<Doctor> doctors;
 
     
     @OneToMany(mappedBy ="clinic")

--- a/server/src/main/java/com/clinicare/server/domain/db/Doctor.java
+++ b/server/src/main/java/com/clinicare/server/domain/db/Doctor.java
@@ -34,8 +34,8 @@ public class Doctor extends User {
     @OneToMany(mappedBy = "doctor")
     private Set<Slot> slots;
 
-    @OneToMany(mappedBy = "doctor")
-    private Set<Appointment> appointments;
+//    @OneToMany(mappedBy = "doctor")
+//    private Set<Appointment> appointments;
 
 //    @OneToMany(mappedBy = "doctor", orphanRemoval = true, cascade = CascadeType.ALL)
 //    @JsonManagedReference(value = "doctor-doctorClinics")
@@ -44,5 +44,5 @@ public class Doctor extends User {
     @ManyToMany
     @JoinTable(name = "doctor_clinics", joinColumns = @JoinColumn(name = "doctor_id"), inverseJoinColumns = @JoinColumn(name = "clinic_id"))
     @JsonIgnoreProperties("doctors")
-    private List<Clinic> clinics;
+    private List<Clinic> doctorClinics;
 }

--- a/server/src/main/java/com/clinicare/server/domain/db/Doctor.java
+++ b/server/src/main/java/com/clinicare/server/domain/db/Doctor.java
@@ -4,7 +4,6 @@ import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -14,7 +13,7 @@ import java.util.List;
 @Entity
 @Data
 @AllArgsConstructor
-@EqualsAndHashCode(callSuper=false)
+@EqualsAndHashCode(callSuper = false)
 @NoArgsConstructor
 @PrimaryKeyJoinColumn(name = "id")
 @Table(name = "doctors")
@@ -32,13 +31,18 @@ public class Doctor extends User {
     @Column(name = "salary")
     private Double salary;
 
-    @OneToMany(mappedBy ="doctor")
+    @OneToMany(mappedBy = "doctor")
     private Set<Slot> slots;
 
-    @OneToMany(mappedBy ="doctor")
+    @OneToMany(mappedBy = "doctor")
     private Set<Appointment> appointments;
 
-    @OneToMany(mappedBy = "doctor", orphanRemoval = true)
-    @JsonManagedReference(value = "doctor-doctorClinics")
-    private List<DoctorClinic> doctorClinics;
+//    @OneToMany(mappedBy = "doctor", orphanRemoval = true, cascade = CascadeType.ALL)
+//    @JsonManagedReference(value = "doctor-doctorClinics")
+//    private List<DoctorClinic> doctorClinics;
+
+    @ManyToMany
+    @JoinTable(name = "doctor_clinics", joinColumns = @JoinColumn(name = "doctor_id"), inverseJoinColumns = @JoinColumn(name = "clinic_id"))
+    @JsonIgnoreProperties("doctors")
+    private List<Clinic> clinics;
 }

--- a/server/src/main/java/com/clinicare/server/domain/db/DoctorClinic.java
+++ b/server/src/main/java/com/clinicare/server/domain/db/DoctorClinic.java
@@ -1,7 +1,6 @@
 package com.clinicare.server.domain.db;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -26,6 +25,6 @@ public class DoctorClinic {
 
     @ManyToOne
     @JoinColumn(name = "clinic_id", nullable = false)
-    @JsonManagedReference(value = "clinic-doctorClinics")
+    @JsonBackReference(value = "clinic-doctorClinics")
     private Clinic clinic;
 }

--- a/server/src/main/java/com/clinicare/server/domain/db/User.java
+++ b/server/src/main/java/com/clinicare/server/domain/db/User.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -44,6 +45,10 @@ public class User implements UserDetails {
     @Column(name = "username")
     private String username;
 
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
     @UpdateTimestamp
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
@@ -60,7 +65,7 @@ public class User implements UserDetails {
     )
     @Builder.Default
     // @JsonIgnoreProperties("users")
-    private List<Role> roles = new ArrayList<>(); 
+    private List<Role> roles = new ArrayList<>();
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/server/src/main/java/com/clinicare/server/service/impl/ClinicServiceImpl.java
+++ b/server/src/main/java/com/clinicare/server/service/impl/ClinicServiceImpl.java
@@ -27,9 +27,7 @@ public class ClinicServiceImpl implements ClinicService {
 
     @Override
     public Optional<Clinic> findById(Long id) {
-        return Optional.ofNullable(clinicRepository.findById(id).orElseThrow(
-                () -> new IllegalArgumentException("clinic Id not found")
-        ));
+       return clinicRepository.findById(id);
     }
 
     @Override


### PR DESCRIPTION
1. removed the explicit using of doctor_clinics join table, instead used direct bi-directional many to many relation between doctors & clinics. 

2.  removed the complex logic of adding/updating/removing locations from clinics and implemented a separate locations logic with separate endpoints 

3. checking when updating doctors if password is present it updates it, if not the old one remains as it is. **_should be done in other subclasses of User Class_**

4. added default creation timestamp for user class thus when a user is created, spring injects in the current timestamp into the created_at attribute 

5. removing slots & appointments relation from clinics & appointments from doctors 